### PR TITLE
Clear the api token if the data api says it is invalid.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5572,9 +5572,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.memoize": {
@@ -5754,9 +5754,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "@js-joda/core": "^3.0.0",
     "form-data": "^3.0.0",
     "into-stream": "^5.1.1",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.1"
   }
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -55,6 +55,9 @@ export default class Client
 
         if (!response.ok) {
             const data = await response.json();
+            if (data.messages[0].code === '952') {
+                await this.clearToken();
+            }
             throw new FileMakerError(data.messages[0].code, data.messages[0].message);
         }
 


### PR DESCRIPTION
If the data api is restarted, the files are closed, or the session on the server is otherwise logged out the api token will be invalid.  filemaker has a dedicated error code for an invalid token so we should clear the token if we get that error code.