### PR TITLE
fix(Layout): fix type of GenericPortalData

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ type MyFieldData = {
 
 type MyPortalData = {
     portalA: {
-        name : string;
+        'portalA::name' : string;
     };
     portalB: {
-        name : string;
+        'portalB::name' : string;
     };
 };
 ```

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -9,7 +9,7 @@ export type Numerish = string | number;
 export type FieldValue = string | Numerish;
 export type FieldData = Record<string, FieldValue>;
 
-export type GenericPortalData = Record<string, Record<string, FieldData>>;
+export type GenericPortalData = Record<string, FieldData>;
 
 export type RecordResponse<T extends FieldData = FieldData, U extends GenericPortalData = GenericPortalData> = {
     fieldData : T;


### PR DESCRIPTION
```
export type GenericPortalData = Record<string, Record<string, FieldData>>;
```
GenericPortalData requires a type like 
```
type PortalData = {
    asdf: {
        asdf: {
            "asdf::id": Numerish;
            "asdf::name": string;
        }
    }
}
```

The type should be 
```
export type GenericPortalData = Record<string, FieldData>;
type PortalData = {
    asdf: {
        "asdf::id": Numerish;
        "asdf::name": string;
    }
}
```

The latter worked for me testing the data and is equivalent to the type in 1.1.1 and older.
```
export type GenericPortalData = {
    [key : string] : {
        [key : string] : FieldValue;
    };
};
```