### PR TITLE
fix(Layout): convert boolean true/false for omits to the required "tr…

### DIFF
--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -103,7 +103,7 @@ export type GetResponse<
 export type Query<T extends FieldData = FieldData> = Partial<{
     [key in keyof T] : T[key] | string;
 }> & {
-    omit ?: boolean;
+    omit ?: boolean | 'true' | 'false';
 };
 
 export type File = {
@@ -236,8 +236,18 @@ export default class Layout<T extends FieldData = FieldData, U extends GenericPo
         params : ListParams<T, U> = {},
         ignoreEmptyResult = false
     ) : Promise<GetResponse<T, U>> {
+        // convert any boolean "omit" values in the query in the query to "true" or "false" strings
+        const queryArray = Array.isArray(query) ? query : [query];
+        const omitConvertedQuery = queryArray.map(query => {
+            if (typeof query.omit === 'boolean') {
+                query.omit = query.omit ? 'true' : 'false';
+            }
+
+            return query;
+        });
+
         const request : Record<string, unknown> = {
-            query: Array.isArray(query) ? query : [query],
+            query: omitConvertedQuery,
         };
 
         for (const [key, value] of Object.entries(params)) {

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -236,7 +236,6 @@ export default class Layout<T extends FieldData = FieldData, U extends GenericPo
         params : ListParams<T, U> = {},
         ignoreEmptyResult = false
     ) : Promise<GetResponse<T, U>> {
-        // convert any boolean "omit" values in the query in the query to "true" or "false" strings
         const request : Record<string, unknown> = {
             query: (Array.isArray(query) ? query : [query]).map(query => ({
                 ...query,

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -103,7 +103,7 @@ export type GetResponse<
 export type Query<T extends FieldData = FieldData> = Partial<{
     [key in keyof T] : T[key] | string;
 }> & {
-    omit ?: boolean | 'true' | 'false';
+    omit ?: boolean;
 };
 
 export type File = {
@@ -237,17 +237,11 @@ export default class Layout<T extends FieldData = FieldData, U extends GenericPo
         ignoreEmptyResult = false
     ) : Promise<GetResponse<T, U>> {
         // convert any boolean "omit" values in the query in the query to "true" or "false" strings
-        const queryArray = Array.isArray(query) ? query : [query];
-        const omitConvertedQuery = queryArray.map(query => {
-            if (typeof query.omit === 'boolean') {
-                query.omit = query.omit ? 'true' : 'false';
-            }
-
-            return query;
-        });
-
         const request : Record<string, unknown> = {
-            query: omitConvertedQuery,
+            query: (Array.isArray(query) ? query : [query]).map(query => ({
+                ...query,
+                omit: query.omit?.toString(),
+            })),
         };
 
         for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
Query is typed with
```
{
    omit?: boolean
}
```
but it must actually be a string of `"true"` or `"false"`. This updates the typing to allow those values, as well as to properly convert boolean values to the string format required for the query to the Data API.