### PR TITLE
fix: share the in-flight sign in so a cold token opens one session

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -29,6 +29,7 @@ type ContainerDownload = {
 export default class Client {
     private token: string | null = null;
     private lastCall = 0;
+    private tokenRequest: Promise<string> | null = null;
 
     public constructor(
         private readonly uri: string,
@@ -127,6 +128,18 @@ export default class Client {
             return this.token;
         }
 
+        // Without this, every caller arriving on a cold or expired token opens its own session.
+        // Only the last one is kept in this.token; the rest are never referenced again and never
+        // deleted, so they sit against the server's session limit until it times them out. Sharing
+        // the in-flight request means one login however many callers arrive together.
+        this.tokenRequest ??= this.mintToken().finally(() => {
+            this.tokenRequest = null;
+        });
+
+        return this.tokenRequest;
+    }
+
+    private async mintToken(): Promise<string> {
         const headers = {
             'Content-Type': 'application/json',
             'Authorization': `Basic ${Buffer.from(`${this.username}:${this.password}`).toString('base64')}`,

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -71,6 +71,67 @@ describe('Client', () => {
             await client.request('test');
         });
 
+        it('should sign in once when several requests arrive on a cold token', async () => {
+            fetchMock.post('https://localhost/fmi/data/v1/databases/db/sessions', {
+                status: 200,
+                headers: {'X-FM-Data-Access-Token': 'foo'},
+                body: {},
+            });
+
+            fetchMock.get('https://localhost/fmi/data/v1/databases/db/test', {
+                status: 200,
+                headers: {
+                    'authorization': 'Bearer foo',
+                    'content-type': 'application/json',
+                },
+                body: {response: 'test'},
+            });
+
+            await Promise.all([client.request('test'), client.request('test'), client.request('test')]);
+
+            // one session for the three of them: without sharing the in-flight sign in, each caller
+            // opens its own and every session but the last is orphaned on the server
+            expect(fetchMock).toHaveFetchedTimes(1, new URL('https://localhost/fmi/data/v1/databases/db/sessions'));
+        });
+
+        it('should sign in again after a failed sign in', async () => {
+            fetchMock.postOnce('https://localhost/fmi/data/v1/databases/db/sessions', {
+                status: 400,
+                body: {messages: [{code: '0', message: 'error'}]},
+            });
+
+            await expect(client.request('test')).rejects.toEqual(new FileMakerError('0', 'error'));
+
+            fetchMock.post('https://localhost/fmi/data/v1/databases/db/sessions', {
+                status: 200,
+                headers: {'X-FM-Data-Access-Token': 'foo'},
+                body: {},
+            });
+
+            fetchMock.get('https://localhost/fmi/data/v1/databases/db/test', {
+                status: 200,
+                headers: {
+                    'authorization': 'Bearer foo',
+                    'content-type': 'application/json',
+                },
+                body: {response: 'test'},
+            });
+
+            // a rejected sign in must not be left cached, or the client can never recover
+            await expect(client.request('test')).resolves.toBe('test');
+        });
+
+        it('should reject every waiter when the shared sign in fails', async () => {
+            fetchMock.post('https://localhost/fmi/data/v1/databases/db/sessions', {
+                status: 400,
+                body: {messages: [{code: '0', message: 'error'}]},
+            });
+
+            const results = await Promise.allSettled([client.request('test'), client.request('test')]);
+
+            expect(results.map(result => result.status)).toEqual(['rejected', 'rejected']);
+        });
+
         it('should request a new token after 14 minutes', async () => {
             fetchMock.post('https://localhost/fmi/data/v1/databases/db/sessions', {
                 status: 200,


### PR DESCRIPTION
## The problem

`getToken` has no in-flight guard:

```ts
private async getToken(): Promise<string> {
    if (this.token !== null && Date.now() - this.lastCall < 14 * 60 * 1000) {
        return this.token;
    }
    // POST /sessions ...
}
```

Every caller arriving while the token is `null` or older than 14 minutes passes that check and runs its own sign in. N concurrent callers open **N Data API sessions**. Only the last one is kept in `this.token`; the rest are never referenced again and never `DELETE`d, so they sit against the server's session limit until FileMaker times them out.

It is invisible from outside the library, because `getToken` is private and the retry path that also triggers it lives inside `request`.

## Where we hit it

`tracker-api` serves a page that fires three concurrent `GET /v1/time-entries` after every save. On any cold start that opened three sessions and abandoned two, which is every time someone comes back after a quarter of an hour and logs time.

We first worked around it in the consumer by serialising the first request of an idle period, but that meant mirroring this file's private 14 minute constant from outside, which quietly breaks the moment it changes. Fixing it here removes the workaround and covers every other consumer.

## The change

Share the pending promise, and clear it when it settles:

```ts
this.tokenRequest ??= this.mintToken().finally(() => {
    this.tokenRequest = null;
});

return this.tokenRequest;
```

One sign in however many callers arrive together. Clearing on settle rather than on success matters: a rejected sign in must not stay cached, or the client can never recover from one bad login.

The body of the old `getToken` moves to `mintToken` unchanged, so the sign in itself, its error handling and `lastCall` bookkeeping are untouched.

This also covers the invalid-token retry. `request` nulls the token on code 952 and calls itself, so concurrent retries after a server restart or an admin session clear now coalesce the same way. That path cannot be reached from a subclass at all.

## Tests

Three added to `test/Client.test.ts`, in the existing `fetchMock` style:

- one sign in for three concurrent callers
- a failed sign in is not cached, and the next caller recovers
- every waiter rejects when the shared sign in fails

Verified by mutation rather than assumed: dropping the shared promise fails the first and leaves the other sixteen in that file passing.

`npx jest` 68 passing across the three suites, `npm run lint` clean, `npm run build` succeeds.

## Compatibility

No public API change. `token`, `lastCall`, the 14 minute window, the sign in request and every error are as before. The only new state is one private field.

---

Raised from a fork because I do not have push access on this repo. `maintainer_can_modify` is on.